### PR TITLE
fixed org-ehtml-format-headline

### DIFF
--- a/src/ox-ehtml.el
+++ b/src/ox-ehtml.el
@@ -78,27 +78,32 @@
   "Used to pass info from `org-ehtml-format-headline-wrap' to
   `org-ehtml-format-headine-function'.")
 
-(defun org-ehtml-format-headine-function (&rest args)
-  (let*
-      ((headline org-ehtml-headline)
-       (info org-ehtml-info)
-       (html (apply #'org-html-format-headline args))
-       (begin (number-to-string (org-element-property :begin headline)))
-       (contents-begin (org-element-property :contents-begin headline))
-       (end (number-to-string (if contents-begin
-				  contents-begin
-				(org-element-property :end headline))))
-       (org (org-org-headline headline "" info)))
-    (org-fill-template org-ehtml-wrap-template
-                       `(("html-text" . ,html)
-                         ("org-text"  . ,org)
-                         ("begin"     . ,begin)
-                         ("end"       . ,end)))))
+(defun org-ehtml-format-headline-function (&rest args)
+  (if org-ehtml-headline
+      (let*
+          ((headline org-ehtml-headline)
+           (info org-ehtml-info)
+           (html (apply #'org-html-format-headline-default-function args))
+           (begin (number-to-string (org-element-property :begin headline)))
+           (contents-begin (org-element-property :contents-begin headline))
+           (end (number-to-string (if contents-begin
+                                      contents-begin
+                                    (org-element-property :end headline))))
+           (org (org-org-headline headline "" info)))
+        (org-fill-template org-ehtml-wrap-template
+                           `(("html-text" . ,html)
+                             ("org-text"  . ,org)
+                             ("begin"     . ,begin)
+                             ("end"       . ,end))))
+    ""))
 
 (defun org-ehtml-format-headline-wrap (headline contents info)
   (if org-ehtml-editable-headlines
       (let ((org-html-format-headline-function
-             #'org-ehtml-format-headine-function)
+             #'org-ehtml-format-headline-function)
+            (info (plist-put info
+                             :html-format-headline-function
+                             'org-ehtml-format-headline-function))
             (org-ehtml-headline headline)
             (org-ehtml-info info))
         (org-html-headline headline contents info))


### PR DESCRIPTION
1. org-ehtml-format-headline-function had a typo (headine vs headline)
2. org-ehtml-format-headline-function can't handle a nil headline (I'm not sure why this can happen, but it does on some of my org files)
3. org-html-headline looks at the plist on info to find the html-format-headline-function, so let-binding org-html-format-headline-function doesn't work (maybe this has changed recently?)
