### PR TITLE
Removed 'nil' from vc-checkin

### DIFF
--- a/README
+++ b/README
@@ -52,7 +52,7 @@ EXTENSIONS
        (lambda (request)
          (let ((file (buffer-file-name (current-buffer))))
            (vc-checkin (list file)
-                       (vc-backend file) nil "edit through org-ehtml"))))
+                       (vc-backend file) "edit through org-ehtml"))))
 
     Authentication
 


### PR DESCRIPTION
With 'nil' passed in this command using Emacs 27.1 git will get stuck
at the Summary: prompt and not commit, by removing this it worked.