### PR TITLE
Fix #36. Src blocks mess up org file

### DIFF
--- a/src/org-ehtml-server.el
+++ b/src/org-ehtml-server.el
@@ -121,10 +121,10 @@ as their only argument.")
            (while (setq entry (pop custom))
              (setq key (car entry) desc (nth 1 entry))
              (when (> (length key) 0)
-               (add-to-list 'prefixes key)
-               (add-to-list
-                'descriptions
-                (format "<a href=\"/agenda/custom/%s\">%s</a>:%s " key key desc))))
+               (cl-pushnew key prefixes)
+               (cl-pushnew
+                (format "<a href=\"/agenda/custom/%s\">%s</a>:%s " key key desc)
+		descriptions)))
            (if (member (car params) prefixes)
                (org-agenda nil (car params))
              (org-ehtml-send-400 proc

--- a/src/org-ehtml-server.el
+++ b/src/org-ehtml-server.el
@@ -124,7 +124,7 @@ as their only argument.")
                (cl-pushnew key prefixes)
                (cl-pushnew
                 (format "<a href=\"/agenda/custom/%s\">%s</a>:%s " key key desc)
-		descriptions)))
+                descriptions)))
            (if (member (car params) prefixes)
                (org-agenda nil (car params))
              (org-ehtml-send-400 proc


### PR DESCRIPTION
The hook functions in `org-export-before-processing-hook` are called directly at the start of `org-export-with-buffer-copy` where the copy of the original org buffer is still unmodified. There we propertize the full text with the `ehtml-pos` property with the original buffer position as value.

The stuff from `def-ehtml-wrap` is called in the export buffer after buffer modifications.
For export, it maps the actual buffer position to the original position stored in the `ehtml-pos` text property.

Small additional fix: Replace `add-to-list` for local variables by `cl-pushnew`.